### PR TITLE
ci: disable sccache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,6 @@ jobs:
           # for its own release process, but recommends using `pyo3` for new
           # projects for some reason.
           args: --release --out dist --find-interpreter
-          sccache: 'true'
           manylinux: auto
       - name: Upload wheels
         uses: actions/upload-artifact@v3
@@ -72,7 +71,6 @@ jobs:
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter
-          sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
@@ -94,7 +92,6 @@ jobs:
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter
-          sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
currently published wheels bark with
```
ImportError: /home/charles/.venvs/vyper/lib/python3.11/site-packages/pyrevm/pyrevm.cpython-311-x86_64-linux-gnu.so: undefined symbol: blst_p2_to_affine
```

apparently, when `sccache` is enabled, libblst (incorrectly) gets linked dynamically instead of statically.